### PR TITLE
allow same pro for ubuntu and arch builds

### DIFF
--- a/aitrack.pro
+++ b/aitrack.pro
@@ -78,11 +78,22 @@ QMAKE_CXXFLAGS += -std=c++17
 unix: CONFIG += link_pkgconfig
 unix: PKGCONFIG += opencv4
 unix: PKGCONFIG += spdlog
-unix: PKGCONFIG += x11-xcb
 unix: PKGCONFIG += Qt5Widgets
 unix: PKGCONFIG += Qt5Gui
 unix: PKGCONFIG += Qt5Network
 unix: PKGCONFIG += Qt5X11Extras
 unix: PKGCONFIG += Qt5Core
+unix: packagesExist(xcb) {
+    PKGCONFIG += xcb
+} else {
+    PKGCONFIG += x11-xcb
+}
+unix: packagesExist(libxsettings-client) {
+    PKGCONFIG += libxsettings-client
+}
+
+unix:{
+    QMAKE_LFLAGS += "-Wl,-rpath,\'\$$ORIGIN/../share/aitrack/lib\'"
+}
 
 LIBS += -L onnxruntime-linux-x64-1.4.0/lib -lonnxruntime -fopenmp

--- a/aitrack.pro
+++ b/aitrack.pro
@@ -85,9 +85,12 @@ unix: PKGCONFIG += Qt5X11Extras
 unix: PKGCONFIG += Qt5Core
 unix: packagesExist(xcb) {
     PKGCONFIG += xcb
-} else {
+}
+
+unix: packagesExist(x11-xcb) {
     PKGCONFIG += x11-xcb
 }
+
 unix: packagesExist(libxsettings-client) {
     PKGCONFIG += libxsettings-client
 }


### PR DESCRIPTION
here's a method that should mean you don't need to maintain a separate ubuntu branch :) i don't have an arch box here to test on though sorry.

Additionally I'm adding $PREFIX/share/aitrack/lib to the rpath with the intention of vendoring onnx lib in there instead of directly in /usr/lib (in case of conflicts etc).

Thanks for this!